### PR TITLE
feat(translations): Update translations to support multiple tool categories

### DIFF
--- a/app/context/LocaleContext.tsx
+++ b/app/context/LocaleContext.tsx
@@ -168,7 +168,10 @@ const translations = {
       stayTuned: 'Hold øje med flere nyttige værktøjer og projekter fra DAT5 fællesskabet!',
       backToTools: 'Tilbage til Værktøjer',
       available: 'Tilgængelig',
-      categorySchedule: 'Skemavisning',
+      categories: {
+        scheduleViewer: "Skemavisning",
+        examViewer: "Examvisning",
+      },
       toolDetails: 'Værktøjsdetaljer',
       releaseDate: 'Udgivelsesdato',
       status: 'Status',
@@ -327,7 +330,10 @@ const translations = {
       stayTuned: 'Stay tuned for more useful tools and projects from the DAT5 community!',
       backToTools: 'Back to Tools',
       available: 'Available',
-      categorySchedule: 'Schedule Viewer',
+      categories: {
+        scheduleViewer: 'Schedule Viewer',
+        examViewer: 'Exam Viewer',
+      },
       toolDetails: 'Tool Details',
       releaseDate: 'Release Date',
       status: 'Status',

--- a/app/tools/au-rooms/page.tsx
+++ b/app/tools/au-rooms/page.tsx
@@ -26,7 +26,7 @@ export default function AURoomsPage() {
               {t('tools.auRooms.title')}
             </h1>
             <span className="px-3 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full text-xs font-medium">
-              {t('tools.categorySchedule')}
+              {t('tools.categories.scheduleViewer')}
             </span>
           </div>
           <p className="text-xl text-gray-600 dark:text-gray-300">

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -14,7 +14,7 @@ const tools = [
     websiteUrl: 'https://auexam.froemosen.dk',
     thumbnailUrl: '/images/tools/au-exams-thumbnail.png',
     developer: { name: 'Kristian Anton Hedegaard', link: 'https://froemosen.dk' },
-    category: 'tools.categorySchedule',
+    category: 'tools.categories.examViewer',
     features: ['tools.auExams.feature1', 'tools.auExams.feature2', 'tools.auExams.feature3']
   },
   {
@@ -27,7 +27,7 @@ const tools = [
     websiteUrl: 'https://au-rooms.omikkel.com',
     thumbnailUrl: '/images/tools/au-rooms-thumbnail.png',
     developer: { name: 'Mikkel Maae Østergaard', link: 'https://mikkelmaae.dev' },
-    category: 'tools.categorySchedule',
+    category: 'tools.categories.scheduleViewer',
     features: ['tools.auRooms.feature1', 'tools.auRooms.feature2', 'tools.auRooms.feature3']
   }
 ]


### PR DESCRIPTION
This pull request refactors how tool categories are handled and displayed by introducing a nested `categories` object in the translations, updating references throughout the codebase to use the new structure. This change improves translation organization and scalability for future categories.

**Translation structure improvements:**

* Updated the `translations` object in `app/context/LocaleContext.tsx` to replace the flat `categorySchedule` key with a nested `categories` object containing `scheduleViewer` and `examViewer` for both Danish and English. [[1]](diffhunk://#diff-ed4076854720ada00634f16050492f76047500d8d42667a2ddb1044b3ab36dd0L171-R174) [[2]](diffhunk://#diff-ed4076854720ada00634f16050492f76047500d8d42667a2ddb1044b3ab36dd0L330-R336)

**Code updates for new category references:**

* Updated the `tools` array in `app/tools/page.tsx` to use `tools.categories.examViewer` and `tools.categories.scheduleViewer` instead of the old `tools.categorySchedule` key for the respective tools. [[1]](diffhunk://#diff-b8b2fadc110966466e8f6f9ebeb2b05826156736a9333f23ed899f722e2b74b6L17-R17) [[2]](diffhunk://#diff-b8b2fadc110966466e8f6f9ebeb2b05826156736a9333f23ed899f722e2b74b6L30-R30)
* Modified `app/tools/au-rooms/page.tsx` to reference `tools.categories.scheduleViewer` when displaying the category badge.